### PR TITLE
Compatibility with Text-2.1.2

### DIFF
--- a/Test/Proctest.hs
+++ b/Test/Proctest.hs
@@ -101,7 +101,7 @@ module Test.Proctest (
 
 import Control.Concurrent (threadDelay)
 import Control.Exception (Exception (..), throw, throwIO)
-import Data.Text
+import Data.Text (Text, unpack)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Typeable
 import qualified Data.ByteString as BS


### PR DESCRIPTION
Text 2.1.2 has introduced a show function, which clashes with Prelude.show in Test/Proctest.hs. This PR changes the Text import in Test/Proctest to only import Text and unpack and thus avoid the clash.